### PR TITLE
feat(transports): add plain XML-RPC as last fallback

### DIFF
--- a/src/transports/_utils.js
+++ b/src/transports/_utils.js
@@ -1,0 +1,3 @@
+import makeError from 'make-error'
+
+export const UnsupportedTransport = makeError('UnsupportedTransport')

--- a/src/transports/auto.js
+++ b/src/transports/auto.js
@@ -1,29 +1,32 @@
-import { InvalidJson } from 'json-rpc-protocol'
-
 import jsonRpc from './json-rpc'
 import xmlRpc from './xml-rpc'
+import xmlRpcJson from './xml-rpc-json'
 
 export default opts => {
-  let call = (jsonRpcCall =>
-    (method, args) => jsonRpcCall(method, args).then(
-      result => {
-        // JSON-RPC seems to be working, remove the test
-        call = jsonRpcCall
+  const factories = [ jsonRpc, xmlRpcJson, xmlRpc ]
 
-        return result
-      },
-      error => {
-        if (error instanceof InvalidJson) {
-          // fallback to XML-RPC
-          call = xmlRpc(opts)
+  const { length } = factories
+  let i = 0
 
+  let call
+  function create () {
+    const current = factories[i++](opts)
+    if (i < length) {
+      call = (method, args) => current(method, args).then(
+        result => {
+          call = current
+          return result
+        },
+        () => {
+          create()
           return call(method, args)
         }
-
-        throw error
-      }
-    )
-  )(jsonRpc(opts))
+      )
+    } else {
+      call = current
+    }
+  }
+  create()
 
   return (method, args) => call(method, args)
 }

--- a/src/transports/json-rpc.js
+++ b/src/transports/json-rpc.js
@@ -1,6 +1,8 @@
 import httpRequestPlus from 'http-request-plus'
 import { format, parse } from 'json-rpc-protocol'
 
+import { UnsupportedTransport } from './_utils'
+
 export default ({ allowUnauthorized, url }) => {
   return (method, args) => httpRequestPlus.post(url, {
     rejectUnauthorized: !allowUnauthorized,
@@ -10,12 +12,27 @@ export default ({ allowUnauthorized, url }) => {
       'Content-Type': 'application/json'
     },
     path: '/jsonrpc'
-  }).readAll('utf8').then(text => {
-    const response = parse(text)
-    if (response.type === 'response') {
-      return response.result
-    }
+  }).readAll('utf8').then(
+    text => {
+      let response
+      try {
+        response = parse(text)
+      } catch (error) {
+        throw new UnsupportedTransport()
+      }
 
-    throw response.error
-  })
+      if (response.type === 'response') {
+        return response.result
+      }
+
+      throw response.error
+    },
+    error => {
+      if (error.response !== undefined) { // HTTP error
+        throw new UnsupportedTransport()
+      }
+
+      throw error
+    }
+  )
 }

--- a/src/transports/xml-rpc-json.js
+++ b/src/transports/xml-rpc-json.js
@@ -14,6 +14,15 @@ const logError = error => {
   throw error
 }
 
+const SPECIAL_CHARS = {
+  '\r': '\\r',
+  '\t': '\\t'
+}
+const SPECIAL_CHARS_RE = new RegExp(
+  Object.keys(SPECIAL_CHARS).join('|'),
+  'g'
+)
+
 const parseResult = result => {
   const status = result.Status
 
@@ -27,7 +36,33 @@ const parseResult = result => {
     throw result.ErrorDescription
   }
 
-  return result.Value
+  const value = result.Value
+
+  // XAPI returns an empty string (invalid JSON) for an empty
+  // result.
+  if (value === '') {
+    return ''
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    // XAPI JSON sometimes contains invalid characters.
+    if (error instanceof SyntaxError) {
+      let replaced
+      const fixedValue = value.replace(SPECIAL_CHARS_RE, match => {
+        replaced = true
+        return SPECIAL_CHARS[match]
+      })
+
+      if (replaced) {
+        return JSON.parse(fixedValue)
+      }
+    }
+
+    console.log(value)
+    throw error
+  }
 }
 
 export default ({
@@ -40,6 +75,7 @@ export default ({
       : createClient
   )({
     host: hostname,
+    path: '/json',
     port,
     rejectUnauthorized: !allowUnauthorized
   })


### PR DESCRIPTION
Still not perfect because, for instance, XML-RPC-JSON works with XenServer 5.0 it's horribly broken and the current system does not fall back properly.

Any idea?